### PR TITLE
Upgrade octokit as locked version was deleted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)


### PR DESCRIPTION
Current lock file can't be built as octokit 4.17.0 was deleted by the project's owners, as this version had errors. 

This upgrades octokit to the fixed version so the bundle can be built. 